### PR TITLE
Add block_size & max file size db option

### DIFF
--- a/src/leveldb.cpp
+++ b/src/leveldb.cpp
@@ -90,6 +90,9 @@ bool Leveldb::open(const std::string &name, const Option& opt)
 {
 #ifndef WIN32
     m_options.create_if_missing = true;
+    m_options.block_size = opt.blockSize;
+    m_options.max_file_size = opt.maxFileSize;
+    
     if (opt.compress) {
         m_options.compression = leveldb::kSnappyCompression;
     } else {

--- a/src/leveldb.h
+++ b/src/leveldb.h
@@ -156,11 +156,15 @@ public:
         bool compress;
         size_t cacheSize;
         size_t writeBufferSize;
+        size_t blockSize;
+        size_t maxFileSize;
 
         Option(void) {
             compress = false;
             cacheSize = 0;
             writeBufferSize = 4*1024*1024;
+            blockSize = 16 * 1024;
+            maxFileSize = 16 * 1024 * 1024;
         }
         ~Option(void) {}
     };
@@ -207,6 +211,8 @@ public:
         bool sync;
         bool binlogEnabled;
         size_t maxBinlogSize;
+        size_t blockSize;
+        size_t maxFileSize;
 
         Option(void) {
             workdir = ".";
@@ -215,6 +221,8 @@ public:
             sync = false;
             binlogEnabled = false;
             maxBinlogSize = 64*1024*1024;
+            blockSize = 16 * 1024;
+            maxFileSize = 16 * 1024 * 1024;
         }
         Option(const Option& opt) { *this = opt; }
         Option& operator =(const Option& opt) {
@@ -227,6 +235,8 @@ public:
                 sync = opt.sync;
                 binlogEnabled = opt.binlogEnabled;
                 maxBinlogSize = opt.maxBinlogSize;
+                blockSize = opt.blockSize;
+                maxFileSize = opt.maxFileSize;
             }
             return *this;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,6 +84,9 @@ void startOneValue(void)
     clusterOption.leveldbopt.compress = opt->compress();
     clusterOption.leveldbopt.cacheSize = opt->lruCacheSize();
     clusterOption.leveldbopt.writeBufferSize = opt->writeBufSize();
+    clusterOption.leveldbopt.blockSize = opt->blockSize();
+    clusterOption.leveldbopt.maxFileSize = opt->maxFileSize();
+    
     for (int i = 0; i < cfg->dbCnt(); ++i) {
         CDbNode* dbcfg = cfg->dbIndex(i);
         clusterOption.dbnames.push_back(dbcfg->db_name);

--- a/src/onevaluecfg.cpp
+++ b/src/onevaluecfg.cpp
@@ -132,6 +132,8 @@ COption::COption() {
     m_compress = false;
     m_lruCacheSize = 0;
     m_writeBufSize = 4;
+    m_blocksize = 16;
+    m_maxfilesize = 16;
 }
 
 COption::~COption() {}
@@ -149,6 +151,18 @@ void COneValueCfg::getDbOption(const TiXmlAttribute* addrAttr) {
         if (0 == strcasecmp(name, "compress")) {
             if (atoi(value) > 0) {
                 m_option.m_compress = true;
+            }
+            continue;
+        }
+        if (0 == strcasecmp(name, "block_size")) {
+            if (atoi(value) > 0) {
+                m_option.m_blcoksize = atoi(value);
+            }
+            continue;
+        }
+        if (0 == strcasecmp(name, "max_file_size")) {
+            if (atoi(value) > 0) {
+                m_option.m_maxfilesize = atoi(value);
             }
             continue;
         }

--- a/src/onevaluecfg.h
+++ b/src/onevaluecfg.h
@@ -74,11 +74,15 @@ public:
     bool compress() const {return m_compress;}
     int lruCacheSize()const {return m_lruCacheSize * 1024 * 1024;} // return bit
     int writeBufSize()const {return m_writeBufSize * 1024 * 1024;}
+    int blockSize() const {return m_blocksize * 1024; }
+    int maxFileSize() const {return m_maxfilesize * 1024 * 1024; }
 private:
     bool m_sync;
     bool m_compress;
     int m_lruCacheSize;
     int m_writeBufSize;
+    int m_blocksize;
+    int m_maxfilesize;
     friend class COneValueCfg;
 };
 


### PR DESCRIPTION
By default rocksdb & leveldb use 4KB block size and 2MB file size, change the defaut block size to 16KB and the max file size to 16MB, and make them a configurable options.
