### PR TITLE
Add support for HyperLogLog PFMERGE command.

### DIFF
--- a/src/cmdhandler.cpp
+++ b/src/cmdhandler.cpp
@@ -834,6 +834,42 @@ void onPFCountCommand(ClientPacket* packet, void*)
 
 void onPFMergeCommand(ClientPacket * packet, void*)
 {
+    RedisProtoParseResult& r = packet->recvParseResult;
+    if(r.tokenCount != 3){
+	packet->setFinishedState(ClientPacket::WrongNumberOfArguments);
+	return;
+    }
+
+    LeveldbCluster* db = packet->proxy()->leveldbCluster();
+    
+    std::string store1, str_register1, val1;
+    XObject key1 = makeStringKey(r.tokens[1].s, r.tokens[1].len, store1);
+    if(db->value(key1, val1)){
+	str_register1 = val1;
+    }else{
+	str_register1 = "";
+    }
+    
+    std::string store2, str_register2, val2;
+    XObject key2 = makeStringKey(r.tokens[2].s, r.tokens[2].len, store2);
+    if(db->value(key2, val2)){
+	str_register2 = val2;
+    }else{
+	str_register2 = "";
+    }
+    THyperLogLog log1(10, str_register1);
+    THyperLogLog log2(10, str_register2);
+
+    std::string result = log1.Merge(log2);
+    XObject value(result.data(), result.size());
+
+    if (db->setValue(key1, value)) {
+        packet->sendBuff.append("+OK\r\n");
+    } else {
+        packet->sendBuff.append("-ERR Unknown error\r\n");
+    }
+
+    packet->setFinishedState(ClientPacket::RequestFinished);
 }
 
 void onPingCommand(ClientPacket* packet, void*)

--- a/src/t_hyperloglog.cpp
+++ b/src/t_hyperloglog.cpp
@@ -110,7 +110,7 @@ int THyperLogLog::CountZero() const
     return count;
 }
 
-void THyperLogLog::Merge(const THyperLogLog & hll)
+std::string THyperLogLog::Merge(const THyperLogLog & hll)
 {
     if (m_ != hll.m_) {
         // TODO: ERROR "number of registers doesn't match"
@@ -120,6 +120,12 @@ void THyperLogLog::Merge(const THyperLogLog & hll)
             register_[r] |= hll.register_[r];
         }
     }
+    
+    std::string result_str(m_, 0);
+    for (uint32_t i = 0; i < m_; ++i) {
+        result_str[i] = register_[i];
+    }
+    return result_str;
 }
 
 //::__builtin_clz(x): 返回左起第一个‘1’之前0的个数

--- a/src/t_hyperloglog.h
+++ b/src/t_hyperloglog.h
@@ -41,7 +41,7 @@ public:
     uint8_t Nclz(uint32_t x, int b);
     
     std::string Add(const char * str, uint32_t len);
-    void Merge(const THyperLogLog & hll);
+    std::string Merge(const THyperLogLog & hll);
     
 protected:
     uint32_t m_;                    // register bit width


### PR DESCRIPTION
```
127.0.0.1:8221> pfadd key1 "value1" "value2"
OK
127.0.0.1:8221> pfadd key2 "value2" "value3"
OK
127.0.0.1:8221> pfmerge key1 key2
OK
127.0.0.1:8221> pfcount key1
"3.004403"
127.0.0.1:8221> pfcount key2
"2.001956"
127.0.0.1:8221> 
```
